### PR TITLE
Add D*cker support

### DIFF
--- a/rednixos-iso-stable.nix
+++ b/rednixos-iso-stable.nix
@@ -88,6 +88,8 @@
     qemuGuest.enable = true;
   };
 
+  virtualisation.docker.enable = true;
+
   virtualisation.vmware.guest.enable = true;
   virtualisation.hypervGuest.enable = true;
   virtualisation.virtualbox.guest.enable = false;
@@ -169,6 +171,7 @@
       "audio"
       "video"
       "input"
+      "docker"
     ];
   };
 

--- a/rednixos-iso-unstable.nix
+++ b/rednixos-iso-unstable.nix
@@ -88,6 +88,8 @@
     qemuGuest.enable = true;
   };
 
+  virtualisation.docker.enable = true;
+
   virtualisation.vmware.guest.enable = true;
   virtualisation.hypervGuest.enable = true;
   virtualisation.virtualbox.guest.enable = false;
@@ -169,6 +171,7 @@
       "audio"
       "video"
       "input"
+      "docker"
     ];
   };
 


### PR DESCRIPTION
Unfortunately Nix hasn't completely taken over yet, so this legacy format is sometimes found in challenges and such. This adds the daemon and gives `red` access to it. Works on my VM.